### PR TITLE
require dependancies

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/lib/plastic_wrap.rb
+++ b/lib/plastic_wrap.rb
@@ -1,10 +1,11 @@
 require "plastic_wrap/version"
 
-module PlasticWrap
-  autoload :CardboardTube, 'plastic_wrap/cardboard_tube'
-  autoload :Heavy, 'plastic_wrap/heavy'
-  autoload :Light, 'plastic_wrap/light'
+require_relative 'plastic_wrap/helpers'
+require_relative 'plastic_wrap/cardboard_tube'
+require_relative 'plastic_wrap/light'
+require_relative 'plastic_wrap/heavy'
 
+module PlasticWrap
   def self.create_wrap(superclass, base_wrap=Heavy)
     klass = Class.new(base_wrap)
     methods = superclass.instance_methods

--- a/plastic_wrap.gemspec
+++ b/plastic_wrap.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_dependency('actionpack')
-  gem.add_dependency('activesupport')
+  gem.add_dependency('rails')
+
+  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "pry"
 end

--- a/spec/heavy_spec.rb
+++ b/spec/heavy_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'time'
+
+RSpec.describe 'PlasticWrap::Heavy' do
+  it 'wraps a class' do
+    require 'rails'
+    require 'sprockets/railtie'
+
+    class MyApp < Rails::Application; end
+
+    require 'plastic_wrap'
+
+    class Leftovers
+      def best_before
+        @best_before ||= Time.parse('2018-02-23 15:08:48 -0500')
+      end
+    end
+
+    class ReadableBestBefore < PlasticWrap.create_wrap(Leftovers)
+      def best_before
+        super.strftime('%m-%y')
+      end
+    end
+
+    expect(ReadableBestBefore.wrap(Leftovers.new).best_before).to eq("02-18")
+  end
+end

--- a/spec/light_spec.rb
+++ b/spec/light_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'time'
+
+RSpec.describe 'PlasticWrap::Light' do
+  it 'wraps a class' do
+    require 'rails'
+    require 'sprockets/railtie'
+
+    class MyApp < Rails::Application; end
+
+    require 'plastic_wrap'
+
+    class Leftovers
+      def best_before
+        @best_before ||= Time.parse('2018-02-23 15:08:48 -0500')
+      end
+    end
+
+    class ReadableBestBeforeLight < PlasticWrap::Light
+      def best_before
+        super.strftime('%m-%y')
+      end
+    end
+
+    expect(ReadableBestBeforeLight.wrap(Leftovers.new).best_before).to eq("02-18")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,23 @@
+require 'pry'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
+  config.disable_monkey_patching!
+  config.warnings = true
+  if config.files_to_run.one?
+    config.default_formatter = "doc"
+  end
+  # config.profile_examples = 10
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
examples don't work due to dependency requirement, requiring `plastic_wrap`
and subclassing PlasticWrap cause `uninitialized constant` errors

Working examples require the host application to know which order to require
plastic wrap classes in for this lib to work

The change of `autoload` to require makes dependency order more explicit (after rails
application has been defined, require plastic wrap and it knows how to load itself)

First test has example of load order requirement